### PR TITLE
Image / File display in edit form

### DIFF
--- a/Resources/views/Form/theme.html.twig
+++ b/Resources/views/Form/theme.html.twig
@@ -114,6 +114,13 @@
 {% macro collection_item(form, allow_delete, button_delete_label, index) %}
     {% spaceless %}
         <div data-form-collection="item" data-form-collection-index="{{ index }}">
+            {% if form.vars.value.path|default(null) is not null %}
+                {% if form.vars.value.path|split('.')|last in ['jpg', 'jpeg', 'png', 'pdf', 'gif'] %}
+                    <img class="ui small bordered image" src="{{ form.vars.value.path|imagine_filter('sylius_small') }}" alt="{{ form.vars.value.type }}" />
+                {% else %}
+                    <h3>{{ form.vars.value.path}}</h3>
+                {% endif %}
+            {% endif %}
             {{ form_widget(form) }}
             {% if allow_delete %}
                 <a href="#" data-form-collection="delete" class="ui red labeled icon button" style="margin-bottom: 1em;">


### PR DESCRIPTION
If there is a collection of file field inside the form (for a custom resource with a collection of images for example) and there one or more image are persisted, display a thumbnail of that image for each. Currently there is nothing displayed, the file field in the edit page looks empty even if there is already a file saved, so it's a bit confusing for the admin.