### PR TITLE
Update messages.cs.yml - Fix czech translation of taxonomy

### DIFF
--- a/Resources/translations/messages.cs.yml
+++ b/Resources/translations/messages.cs.yml
@@ -808,7 +808,7 @@ sylius:
         taxation_settings: 'Nastavení zdanění'
         taxes: 'DPH'
         taxes_total: 'Daně celkem'
-        taxonomy: 'Taxy DPH'
+        taxonomy: 'Taxonomie'
         taxons: 'Taxony'
         terms_and_conditions: 'Obchodní podmínky'
         text: 'Text'


### PR DESCRIPTION
Fix czech translation of taxonomy

 - From `Taxy DPH` to `taxonomie`