### PR TITLE
Fixed apply to all on multiple values selected

### DIFF
--- a/Resources/private/js/sylius-product-attributes.js
+++ b/Resources/private/js/sylius-product-attributes.js
@@ -79,7 +79,7 @@ const copyValueToAllLanguages = function copyValueToAllLanguages() {
         if (input.getAttribute('type') === 'checkbox') {
           input.checked = $masterAttributeInputs[i].checked;
         } else {
-          input.value = $masterAttributeInputs[i].value;
+          $(input).val($masterAttributeInputs.eq(i).val());
         }
       });
     });


### PR DESCRIPTION
| Q                        | A
| --------------- | -----
| Branch?             | 1.7 or master
| Bug fix?             | yes
| New feature?    | no
| BC breaks?       | no
| Deprecations?  | no
| License             | MIT
Issue was, that when user selected multiple values on product attribute select and clicked "Apply to all", only first value was copied to other languages.